### PR TITLE
Refactor Dockerfile for flexibility and rapid code iteration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,28 @@
-#FROM ubuntu:20.04
-#FROM scimma/client:0.7.1
 FROM scimma/client:latest
+
 RUN pip3 install --upgrade pip 
-RUN  mkdir -p /usr/local/src
 RUN yum -y install git unzip python3-pytz python38-pytz postgresql-devel 
-RUN cd /usr/local/src && curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-RUN cd /usr/local/src && unzip awscliv2.zip 
-RUN cd /usr/local/src && ./aws/install
-RUN cd /usr/local/src && rm -rf aws
-#    
-ADD src/housekeeping.py    /root/housekeeping.py
-ADD src/database_api.py    /root/database_api.py
-ADD src/consumer_api.py     /root/consumer_api.py
-ADD src/store_api.py       /root/store_api.py
-ADD src/database_api.py    /root/database_api.py
-ADD src/verify_api.py      /root/verify_api.py 
-ADD src/decision_api.py      /root/decision_api.py
-ADD src/utility_api.py      /root/utility_api.py
-#
-ADD src/housekeeping.toml  /root/housekeeping.toml
-RUN mkdir -p               /root/.config/hop 
-ADD requirements.txt       /root/requirements.txt
-# RUN chmod ugo+rx           /root/housekeeping.py
-# RUN chmod ugo+rwx          /root/housekeeping.toml
-RUN pip3 install -r        /root/requirements.txt
-WORKDIR /root
-#ENTRYPOINT ["/bin/bash"]
+
+WORKDIR /usr/local/src
+RUN curl -s "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip  && \
+    ./aws/install && \
+    rm -rf aws awscliv2.zip
+
+COPY requirements.txt requirements.txt
+RUN pip3 install -r requirements.txt
+
+RUN mkdir -p /root.config/hop /root/src
+
+WORKDIR /root/src
+COPY src/housekeeping.py housekeeping.py
+COPY src/database_api.py database_api.py
+COPY src/consumer_api.py consumer_api.py
+COPY src/store_api.py store_api.py
+COPY src/database_api.py database_api.py
+COPY src/verify_api.py verify_api.py 
+COPY src/decision_api.py decision_api.py
+COPY src/utility_api.py utility_api.py
+COPY src/housekeeping.toml housekeeping.toml
+
 CMD ["./housekeeping.py", "run", "-H",  "hop-prod", "-D", "aws-dev-db", "-S",  "S3-dev"]


### PR DESCRIPTION
* Compound RUN command for AWS download and installation to reduce size of image
* Move Python requirements installation before source code to avoid needless pip reinstall
* Use WORKDIR to remove redundant directory references